### PR TITLE
[R4R] Add set version in mutable tree

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -224,6 +224,11 @@ func (tree *MutableTree) Load() (int64, error) {
 	return tree.LoadVersion(int64(0))
 }
 
+// SetVersion set current version of the tree
+func (tree *MutableTree) SetVersion(version int64) {
+	tree.version = version
+}
+
 // Returns the version number of the latest version found
 func (tree *MutableTree) LoadVersion(targetVersion int64) (int64, error) {
 	roots, err := tree.ndb.getRoots()

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -224,9 +224,10 @@ func (tree *MutableTree) Load() (int64, error) {
 	return tree.LoadVersion(int64(0))
 }
 
-// SetVersion set current version of the tree
+// SetVersion set current version of the tree. Only used in upgrade
 func (tree *MutableTree) SetVersion(version int64) {
 	tree.version = version
+	tree.ndb.latestVersion = version
 }
 
 // Returns the version number of the latest version found


### PR DESCRIPTION
when we add a new store in upgrade, the initial version is 0, so it would be different from other stores, it would make state_sync or other tools which depend on version more difficult. 

so if we set the current version before the first commit, we could make the version of the new store the same as other stores.