### PR TITLE
[R4R] Fix memory consume during taking snapshot for state sync

### DIFF
--- a/node.go
+++ b/node.go
@@ -454,16 +454,12 @@ func (node *Node) traverseInRangeDiscardNode(t *ImmutableTree, start, end []byte
 	if !node.isLeaf() || (startOrAfter && beforeEnd) {
 		stop = cb(node, depth)
 		if stop {
-			node.leftHash = nil
-			node.rightHash = nil
 			node.leftNode = nil
 			node.rightNode = nil
-			distroyCurrentNode(node)
 			return stop
 		}
 	}
 	if node.isLeaf() {
-		distroyCurrentNode(node)
 		return stop
 	}
 
@@ -471,9 +467,7 @@ func (node *Node) traverseInRangeDiscardNode(t *ImmutableTree, start, end []byte
 		// check lower nodes, then higher
 		if afterStart {
 			child := node.getLeftNode(t)
-			node.leftHash = nil
 			node.leftNode = nil
-			distroyCurrentNode(node)
 			stop = child.traverseInRangeDiscardNode(t, start, end, ascending, inclusive, depth+1, cb)
 		}
 		if stop {
@@ -481,18 +475,14 @@ func (node *Node) traverseInRangeDiscardNode(t *ImmutableTree, start, end []byte
 		}
 		if beforeEnd {
 			child := node.getRightNode(t)
-			node.rightHash = nil
 			node.rightNode = nil
-			distroyCurrentNode(node)
 			stop = child.traverseInRangeDiscardNode(t, start, end, ascending, inclusive, depth+1, cb)
 		}
 	} else {
 		// check the higher nodes first
 		if beforeEnd {
 			child := node.getRightNode(t)
-			node.rightHash = nil
 			node.rightNode = nil
-			distroyCurrentNode(node)
 			stop = child.traverseInRangeDiscardNode(t, start, end, ascending, inclusive, depth+1, cb)
 		}
 		if stop {
@@ -500,22 +490,12 @@ func (node *Node) traverseInRangeDiscardNode(t *ImmutableTree, start, end []byte
 		}
 		if afterStart {
 			child := node.getLeftNode(t)
-			node.leftHash = nil
 			node.leftNode = nil
-			distroyCurrentNode(node)
 			stop = child.traverseInRangeDiscardNode(t, start, end, ascending, inclusive, depth+1, cb)
 		}
 	}
 
 	return stop
-}
-
-func distroyCurrentNode(node *Node) {
-	node.key = nil
-	node.value = nil
-	if node.leftHash == nil && node.rightHash == nil {
-		node = nil
-	}
 }
 
 // Only used in testing...

--- a/node.go
+++ b/node.go
@@ -383,7 +383,7 @@ func (node *Node) traverse(t *ImmutableTree, ascending bool, cb func(*Node) bool
 
 // traverseFirst is a wrapper over traverseInRange when we want the whole tree and will traverse the leaf nodes
 func (node *Node) traverseFirst(t *ImmutableTree, ascending bool, cb func(*Node) bool) bool {
-	return node.traverseInRange(t, nil, nil, ascending, false, 0, func(node *Node, depth uint8) bool {
+	return node.traverseInRangeDiscardNode(t, nil, nil, ascending, false, 0, func(node *Node, depth uint8) bool {
 		return cb(node)
 	})
 }
@@ -437,6 +437,85 @@ func (node *Node) traverseInRange(t *ImmutableTree, start, end []byte, ascending
 	}
 
 	return stop
+}
+
+// This method doesn't hold any reference to loaded node, its cb's responsibility to decide whether hold Node reference
+// If cb (like usage in state sync) don't need hold a reference to loaded Node, the memory footprint will be near to zero
+func (node *Node) traverseInRangeDiscardNode(t *ImmutableTree, start, end []byte, ascending bool, inclusive bool, depth uint8, cb func(*Node, uint8) bool) bool {
+	afterStart := start == nil || bytes.Compare(start, node.key) < 0
+	startOrAfter := start == nil || bytes.Compare(start, node.key) <= 0
+	beforeEnd := end == nil || bytes.Compare(node.key, end) < 0
+	if inclusive {
+		beforeEnd = end == nil || bytes.Compare(node.key, end) <= 0
+	}
+
+	// Run callback per inner/leaf node.
+	stop := false
+	if !node.isLeaf() || (startOrAfter && beforeEnd) {
+		stop = cb(node, depth)
+		if stop {
+			node.leftHash = nil
+			node.rightHash = nil
+			node.leftNode = nil
+			node.rightNode = nil
+			distroyCurrentNode(node)
+			return stop
+		}
+	}
+	if node.isLeaf() {
+		distroyCurrentNode(node)
+		return stop
+	}
+
+	if ascending {
+		// check lower nodes, then higher
+		if afterStart {
+			child := node.getLeftNode(t)
+			node.leftHash = nil
+			node.leftNode = nil
+			distroyCurrentNode(node)
+			stop = child.traverseInRangeDiscardNode(t, start, end, ascending, inclusive, depth+1, cb)
+		}
+		if stop {
+			return stop
+		}
+		if beforeEnd {
+			child := node.getRightNode(t)
+			node.rightHash = nil
+			node.rightNode = nil
+			distroyCurrentNode(node)
+			stop = child.traverseInRangeDiscardNode(t, start, end, ascending, inclusive, depth+1, cb)
+		}
+	} else {
+		// check the higher nodes first
+		if beforeEnd {
+			child := node.getRightNode(t)
+			node.rightHash = nil
+			node.rightNode = nil
+			distroyCurrentNode(node)
+			stop = child.traverseInRangeDiscardNode(t, start, end, ascending, inclusive, depth+1, cb)
+		}
+		if stop {
+			return stop
+		}
+		if afterStart {
+			child := node.getLeftNode(t)
+			node.leftHash = nil
+			node.leftNode = nil
+			distroyCurrentNode(node)
+			stop = child.traverseInRangeDiscardNode(t, start, end, ascending, inclusive, depth+1, cb)
+		}
+	}
+
+	return stop
+}
+
+func distroyCurrentNode(node *Node) {
+	node.key = nil
+	node.value = nil
+	if node.leftHash == nil && node.rightHash == nil {
+		node = nil
+	}
 }
 
 // Only used in testing...


### PR DESCRIPTION
discard any reference to the Node generated during traversing iavl tree because state sync only needs serialized node. But we have to decode beforehand to get left and right hash.

This reduces memory cost for snapshotting height 451000 in QA where has 10000000 iavl nodes (5MM accounts) from more than 2G to less than 50M 

before: 
![profile001](https://user-images.githubusercontent.com/1442921/61989826-668ac000-b067-11e9-9c55-14b73639a84d.png)

after:
![profile002](https://user-images.githubusercontent.com/1442921/61989827-6be80a80-b067-11e9-906b-3be6af79456c.png)
